### PR TITLE
Documentation Update

### DIFF
--- a/IDA Maple Script/FuncOutput/OnInvOperationOut.txt
+++ b/IDA Maple Script/FuncOutput/OnInvOperationOut.txt
@@ -22,19 +22,19 @@ if :
 while()
 CInPacket::Decode1()
 CInPacket::Decode1()
-      nCurItemID = (signed __int16)CInPacket::Decode2(iPacket);
-          GW_ItemSlotBase::Decode(&pItem, iPacket);
+CInPacket::Decode2()
+ItemSlotBase::Decode()
 while()
-          nBagMaxSlot = (signed __int16)CInPacket::Decode2(iPacket);
+CInPacket::Decode2()
 while()
-          v61 = (signed __int16)CInPacket::Decode2(iPacket);
+CInPacket::Decode2()
 CInPacket::Decode1()
 while()
-          v99 = CInPacket::Decode8(iPacket);
-          v101 = CInPacket::Decode4(iPacket);
-          nNumber = (signed __int16)CInPacket::Decode2(iPacket);
-          v129 = CInPacket::Decode2(iPacket);
-          GW_ItemSlotBase::Decode(&v226, iPacket);
+CInPacket::Decode8()
+CInPacket::Decode4()
+CInPacket::Decode2()
+CInPacket::Decode2()
+ItemSlotBase::Decode()
 while()
 while()
 while()

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## Technical Stack
 |  | Target | Tested |
 | --- | --- | --- |
-| Python | 3.8.5 | 3.8.6 |
+| Python | 3.8.5 | 3.6.12 & 3.8.6 |
 | IDA Pro 32-bit | 7.0 | 7.0 |
 | Editor | Atom | Atom |
 | CLI Interpretor | cmd | pwsh 7.0 |
@@ -26,7 +26,8 @@ Other variants for contributors to test:
   - [x] Python 2.7
     - **NOT COMPATIBLE:** use of os.scandir() makes it non-backwards compatible with versions older than 3.6
   - [x] Python 3.6
-    - **NOT COMPATIBLE:** probably a result of how f-strings handle backslashes
+    - <del>**NOT COMPATIBLE:** probably a result of how f-strings handle backslashes</del>
+    - *Update: Fixed as of commit 10a9fd86c4da264ef6d1d73a6aca248343cf63f6*
   - [ ] IDA 6.8
   - [ ] IDA 7.5
   - [ ] IDLE


### PR DESCRIPTION
**`Python 3.6` tested to be Compatible post-`f-string` fix**
![image](https://user-images.githubusercontent.com/25145447/94980893-5e2def00-0560-11eb-88c3-78380aedf10b.png)


No idea why `IDA Maple Script/FuncOutput/OnInvOperationOut.txt` had different results.
Probably should have `.gitignore` the output folder...